### PR TITLE
fix: provide core settings for base rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clean": "lerna clean",
     "lint": "eslint '**/*.js' .eslintrc.js --ignore-pattern='!.eslintrc.js'",
     "format": "yarn lint --fix",
-    "test": "node packages/commitlint-config && node packages/eslint-config-base && node packages/eslint-config-react && node packages/eslint-config-react/hooks && node packages/eslint-config-prettier && node packages/eslint-config-prettier/react"
+    "test": "node packages/commitlint-config && node packages/eslint-config-base && node packages/eslint-config-base/core && node packages/eslint-config-react && node packages/eslint-config-react/hooks && node packages/eslint-config-prettier && node packages/eslint-config-prettier/react"
   },
   "husky": {
     "hooks": {

--- a/packages/eslint-config-base/core.js
+++ b/packages/eslint-config-base/core.js
@@ -1,0 +1,8 @@
+// Just include barebone set of rules without any other dependencies to allow
+// for other rules to have better control in ordering their extensions. See
+// https://github.com/reside-eng/lint-config/blob/master/packages/eslint-config-react/eslint-config-react.js
+// for more info around this need.
+module.exports = {
+  extends: ['./rules/imports'].map(require.resolve),
+  rules: {},
+};

--- a/packages/eslint-config-base/eslint-config-base.js
+++ b/packages/eslint-config-base/eslint-config-base.js
@@ -2,7 +2,7 @@ module.exports = {
   extends: [
     'eslint-config-airbnb-base',
     '@side-eng/eslint-config-prettier',
-    './rules/imports',
+    './core',
   ].map(require.resolve),
   rules: {},
 };

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -5,6 +5,7 @@
   "license": "UNLICENSED",
   "files": [
     "eslint-config-base.js",
+    "core.js",
     "rules"
   ],
   "dependencies": {

--- a/packages/eslint-config-react/eslint-config-react.js
+++ b/packages/eslint-config-react/eslint-config-react.js
@@ -1,7 +1,11 @@
 module.exports = {
   extends: [
     'eslint-config-airbnb',
-    '@side-eng/eslint-config-base',
+    // We only want @side-eng/eslint-config-base/core (rules only) so we can
+    // properly override eslint-config-airbnb (which already includes
+    // eslint-config-airbnb-base) without blowing away some of their settings we
+    // still want.
+    '@side-eng/eslint-config-base/core',
     '@side-eng/eslint-config-prettier/react',
     './rules/react',
   ].map(require.resolve),


### PR DESCRIPTION
Allow consumer to just get the barebone set of rules for eslint-config-base so they can properly extend other possible conflicing configs in the correct order.