### PR TITLE
fix: enforce consistent single quote

### DIFF
--- a/packages/eslint-config-base/core.js
+++ b/packages/eslint-config-base/core.js
@@ -3,6 +3,8 @@
 // https://github.com/reside-eng/lint-config/blob/master/packages/eslint-config-react/eslint-config-react.js
 // for more info around this need.
 module.exports = {
-  extends: ['./rules/errors', './rules/imports'].map(require.resolve),
+  extends: ['./rules/errors', './rules/imports', './rules/style'].map(
+    require.resolve,
+  ),
   rules: {},
 };

--- a/packages/eslint-config-base/rules/style.js
+++ b/packages/eslint-config-base/rules/style.js
@@ -1,0 +1,10 @@
+// The following are stylistic ESLint rules. Since we are using Prettier, these
+// are only intented to be used to override or re-enable some style rules that
+// Prettier is not concerned about.
+module.exports = {
+  rules: {
+    // Prettier is not concerned with turning single/double quotes into template
+    // literals or vice versa. https://github.com/prettier/prettier/issues/2996
+    quotes: ['error', 'single', { avoidEscape: true }],
+  },
+};


### PR DESCRIPTION
Will switch template literals to single quote if there is no placeholders