### PR TITLE
fix(ci): dependabot PRs fixes

### DIFF
--- a/.github/workflows/verify-dependabot.yml
+++ b/.github/workflows/verify-dependabot.yml
@@ -1,12 +1,15 @@
-name: Verify
+name: Verify (dependabot)
 
-on: [pull_request]
+on:
+  pull_request_target:
+    branches:
+      - master
 
 jobs:
   build:
     name: Build and Verify
     runs-on: ${{ matrix.os }}
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor == 'dependabot[bot]'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
         uses: actions/setup-node@v2.1.5


### PR DESCRIPTION
### Description
- Dependabot checks for this repository need access to secrets in order to be tested. Recent changes at Github prevents "normal" PRs from Dependabot to be tested (since they now get a read-only Github token and no secrets).
- This PR changes that allowing Dependabot PRs to run in a "trusted" environment again via `pull_request_target`.

See https://securitylab.github.com/research/github-actions-preventing-pwn-requests
See https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/
See https://github.com/dependabot/dependabot-core/issues/3253

### Reviewer Testing

The following steps are required for testing and verifying.
- Wait for a `dependabot[bot]` PR and hope it succeeds
- Create a "user" PR (like this one) and see that that the Checks run as normal

### Relevant Tickets (Please add `closes`, `refs`, etc)

- ref [PLAT-681](https://residenetwork.atlassian.net/browse/PLAT-681)