### PR TITLE
fix: update extends for eslint-config-prettier v8 changes

### DIFF
--- a/packages/eslint-config-prettier/react.js
+++ b/packages/eslint-config-prettier/react.js
@@ -1,9 +1,7 @@
 module.exports = {
   extends: [
     'plugin:prettier/recommended',
-    ...['eslint-config-prettier', './rules/prettier'].map(
-      require.resolve,
-    ),
+    ...['eslint-config-prettier', './rules/prettier'].map(require.resolve),
   ],
   rules: {},
 };

--- a/packages/eslint-config-prettier/react.js
+++ b/packages/eslint-config-prettier/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   extends: [
     'plugin:prettier/recommended',
-    ...['eslint-config-prettier/react', './rules/prettier'].map(
+    ...['eslint-config-prettier', './rules/prettier'].map(
       require.resolve,
     ),
   ],


### PR DESCRIPTION
Dependabot upgraded eslint-config-prettier in https://github.com/reside-eng/lint-config/pull/107 which included a breaking change: 

https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21

This caused an error message when using this config in a new repo:
```(node:8408) UnhandledPromiseRejectionWarning: Error: Cannot read config file: /Users/jonathanmay/side/documents-ui/node_modules/eslint-config-prettier/react.js
Error: "prettier/react" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
Referenced from: /Users/jonathanmay/side/documents-ui/node_modules/@side/eslint-config-prettier/react.js```