### PR TITLE
fix: replace `jest/all` with `jest/recommended`

### DIFF
--- a/packages/eslint-config-jest/eslint-config-jest.js
+++ b/packages/eslint-config-jest/eslint-config-jest.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: ['plugin:jest/recommended'],
   rules: {
-    'jest/prefer-expect-assertions': 0,
     'jest/prefer-lowercase-title': [
       'error',
       {
@@ -9,6 +8,5 @@ module.exports = {
       },
     ],
     'jest/no-disabled-tests': 0,
-    'jest/no-hooks': 0,
   },
 };

--- a/packages/eslint-config-jest/eslint-config-jest.js
+++ b/packages/eslint-config-jest/eslint-config-jest.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:jest/all'],
+  extends: ['plugin:jest/recommended'],
   rules: {
     'jest/prefer-expect-assertions': 0,
     'jest/prefer-lowercase-title': [


### PR DESCRIPTION
## Summary

Jest publishes a recommended ESLint ruleset as part of its `eslint-config-jest` package. However, it looks like this repo has been using `jest/all` as one of its extended rulesets. 

`jest/all` enables every single lint rule provided by `eslint-config-jest`. 

From the [docs](https://github.com/jest-community/eslint-plugin-jest#all) for `eslint-config-jest` regarding `jest/all` (emphasis added):
> While the `recommended` and `style` configurations only change in major versions, _the `all` configuration may change in any release_ and is thus unsuited for installations requiring long-term consistency.

This PR replaces `jest/all` with `jest/recommended`, with the primary reason for the change being that Jest only recommends enabling a subset of its rules by default. 

If `jest/all` was intentionally chosen over `jest/recommended`, feel free to reject this PR. 

## Changes

- Replaced `jest/all` with `jest/recommended` in this config's `extends` field.
- Removed overrides no longer needed.
