### PR TITLE
feat: disallow `React.FC` for react projects

### DIFF
--- a/packages/eslint-config-react/eslint-config-react.js
+++ b/packages/eslint-config-react/eslint-config-react.js
@@ -7,6 +7,7 @@ module.exports = {
     // still want.
     '@side/eslint-config-base/core',
     '@side/eslint-config-prettier/react',
+    './rules/base',
     './rules/react',
     './rules/import',
   ].map(require.resolve),

--- a/packages/eslint-config-react/rules/base.js
+++ b/packages/eslint-config-react/rules/base.js
@@ -1,0 +1,16 @@
+module.exports = {
+  rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'react',
+            importNames: ['FC'],
+            message: `Do not use React.FC per proposal <https://github.com/reside-eng/guidelines/blob/main/rfcs/ui-patterns/001-disalllow-react-fc.md>`,
+          },
+        ],
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Breaking Changes

- Added a new error lint rule to the react lint config that disallows importing `React.FC`