### PR TITLE
feat: update rules for default exports [PLAT-1239]

### DIFF
--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -93,6 +93,21 @@ module.exports = {
         ],
       },
     ],
+    /**
+     * Use named exports over default exports
+     * @link https://github.com/reside-eng/guidelines/blob/main/rfcs/shared-patterns/typescript/001-consistent-import-export.md
+     */
+    'import/prefer-default-export': 'off',
+    'import/no-default-export': 'error',
   },
-  overrides: [...getNoExtraneousDepsOverrides()],
+  overrides: [
+    ...getNoExtraneousDepsOverrides(),
+    // This override enables default exports for files that require them.
+    {
+      files: ['jest.config.{js,mjs,ts}'],
+      rules: {
+        'import/no-default-export': 'off',
+      },
+    },
+  ],
 };

--- a/packages/eslint-config-react/eslint-config-react.js
+++ b/packages/eslint-config-react/eslint-config-react.js
@@ -8,6 +8,7 @@ module.exports = {
     '@side/eslint-config-base/core',
     '@side/eslint-config-prettier/react',
     './rules/react',
+    './rules/import',
   ].map(require.resolve),
   rules: {},
 };

--- a/packages/eslint-config-react/rules/import.js
+++ b/packages/eslint-config-react/rules/import.js
@@ -1,0 +1,24 @@
+module.exports = {
+  overrides: [
+    /**
+     * This override enables default exports for files that require them.
+     * @link https://github.com/reside-eng/guidelines/blob/main/rfcs/shared-patterns/typescript/001-consistent-import-export.md
+     */
+    {
+      files: [
+        // Storybook stories
+        '**/*.stories.{jsx,tsx}',
+
+        // Next.js pages and API routes
+        'src/pages/**/*.{jsx,tsx}',
+        'pages/**/*.{jsx,tsx}',
+
+        // Next.js config
+        'next.config.{js,mjs}',
+      ],
+      rules: {
+        'import/no-default-export': 'off',
+      },
+    },
+  ],
+};


### PR DESCRIPTION
This PR updates our lint config to adhere to the merged proposal on import/export patterns: reside-eng/guidelines#2

## Changes

- Turned off `import/prefer-default-export`.
- Turned on `import/no-default-export`.
- Added overrides to allow default exports for the following scenarios:
  - Storybook stories
  - Next.js pages and API routes
  - Next.js config
  - Jest config