### PR TITLE
fix: add missing default export overrides

### DIFF
--- a/packages/eslint-config-react/rules/import.js
+++ b/packages/eslint-config-react/rules/import.js
@@ -9,9 +9,13 @@ module.exports = {
         // Storybook stories
         '**/*.stories.{jsx,tsx}',
 
-        // Next.js pages and API routes
+        // Next.js pages
         'src/pages/**/*.{jsx,tsx}',
         'pages/**/*.{jsx,tsx}',
+
+        // Next.js API routes
+        'src/pages/api/**/*.{js,ts}',
+        'pages/api/**/*.{js,ts}',
 
         // Next.js config
         'next.config.{js,mjs}',


### PR DESCRIPTION
## Changes

Added missing overrides for Next.js API routes. These were missed the first time because the files in `**/api/**` do not use JSX, so the extensions did not match up.