### PR TITLE
chore(dev-deps): update eslint-config-airbnb@19.0.4

### DIFF
--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@side/eslint-config-base": "0.13.1",
     "@side/eslint-config-prettier": "0.4.7",
-    "eslint-config-airbnb": "^19.0.2",
+    "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.27.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2205,7 +2205,7 @@ eslint-config-airbnb-base@15.0.0, eslint-config-airbnb-base@^15.0.0:
     object.entries "^1.1.5"
     semver "^6.3.0"
 
-eslint-config-airbnb@^19.0.2:
+eslint-config-airbnb@^19.0.4:
   version "19.0.4"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz#84d4c3490ad70a0ffa571138ebcdea6ab085fdc3"
   integrity sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==


### PR DESCRIPTION
https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb/CHANGELOG.md#1903--2021-12-24

We're a couple revisions behind and currently there's an error with the syntax on the 1react/function-component-definition` from airbnb:
```
> yarn lint
yarn run v1.22.17
$ next lint --dir .
info  - Loaded env from /Users/jesse/Code/template-nextjs/.env.local
info  - Loaded env from /Users/jesse/Code/template-nextjs/.env
Error: .eslintrc.js » @side/eslint-config-react » /Users/jesse/Code/template-nextjs/node_modules/eslint-config-airbnb/index.js » /Users/jesse/Code/template-nextjs/node_modules/eslint-config-airbnb/rules/react.js:
	Configuration for rule "react/function-component-definition" is invalid:
	Value ["function-declaration","function-expression"] should be equal to one of the allowed values.

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```