### PR TITLE
fix: turn off class-methods-use-this rule

### DIFF
--- a/packages/eslint-config-base/rules/errors.js
+++ b/packages/eslint-config-base/rules/errors.js
@@ -1,4 +1,11 @@
 module.exports = {
+  rules: {
+    /**
+     * Turn off class methods use this
+     * @link https://github.com/reside-eng/guidelines/blob/main/rfcs/shared-patterns/typescript/002-class-methods-use-this.md
+     */
+    'class-methods-use-this': 0,
+  },
   overrides: [
     {
       files: ['bin/**', 'scripts/**'],


### PR DESCRIPTION
Updates our eslint rules for this RFC:  https://github.com/reside-eng/guidelines/blob/main/rfcs/shared-patterns/typescript/002-class-methods-use-this.md

### Changes
set the rule `class-methods-use-this` to off