### PR TITLE
feat: allow reordering of function declarations

### DIFF
--- a/packages/eslint-config-react/rules/base.js
+++ b/packages/eslint-config-react/rules/base.js
@@ -1,5 +1,13 @@
 module.exports = {
   rules: {
+    'no-use-before-define': [
+      'error',
+      {
+        functions: false,
+        classes: true,
+        variables: true,
+      },
+    ],
     'no-restricted-imports': [
       'error',
       {


### PR DESCRIPTION
### Changes

This PR turns off the ESLint rule [`no-use-before-define`](https://eslint.org/docs/rules/no-use-before-define) for function declarations. Classes and variables will remain subject to this rule.