### PR TITLE
fix: disable `arrow-body-style` lint rule

### DIFF
--- a/packages/eslint-config-base/rules/errors.js
+++ b/packages/eslint-config-base/rules/errors.js
@@ -5,6 +5,21 @@ module.exports = {
      * @link https://github.com/reside-eng/guidelines/blob/main/rfcs/shared-patterns/typescript/002-class-methods-use-this.md
      */
     'class-methods-use-this': 0,
+    /**
+     * Both forms of arrow functions are allowed.
+     *
+     * {@link https://residenetwork.atlassian.net/wiki/spaces/PLAT/pages/2570780871/UI+Working+Group+Meetings UI WG meeting decision on March 25, 2022}
+     *
+     * @example
+     * ```ts
+     * const foo = () => {
+     *   return 'bar';
+     * };
+     *
+     * const foo = () => 'bar';
+     * ```
+     */
+    'arrow-body-style': 0,
   },
   overrides: [
     {


### PR DESCRIPTION
## Changes

Disabled the [`arrow-body-style`](https://eslint.org/docs/rules/arrow-body-style) lint rule in accordance with the UI Working Group decision from the March 25, 2022 meeting.