### PR TITLE
fix: correct TypeScript parsing issues

### DIFF
--- a/packages/eslint-config-typescript/README.md
+++ b/packages/eslint-config-typescript/README.md
@@ -14,19 +14,19 @@ Install this package and its peer dependencies.
 
 ## Usage
 
-Once all peer dependencies have been added to your project, add this configuration to your project's `.eslintrc.js`.
+Once all peer dependencies have been added to your project, add this configuration to your project's ESLint configuration.
 
-```js
-// .eslintrc.js
-module.exports = {
-  extends: ['@side/typescript'],
-  overrides: [
+```jsonc
+// .eslintrc
+{
+  "extends": ["@side/typescript"],
+  "overrides": [
     {
-      files: ['*.ts', '*.tsx'], // you may remove '*.tsx' if you don't use React
-      parser: '@typescript-eslint/parser',
-    },
-  ],
-};
+      "files": ["**/*.ts?(x)"], // you may remove `?(x)` if you don't use React
+      "parser": "@typescript-eslint/parser"
+    }
+  ]
+}
 ```
 
 ### Omitting Strong Type Checks
@@ -35,21 +35,49 @@ Many of the recommended [rules](https://typescript-eslint.io/rules/) provided by
 
 > See [Linting with Type Information](https://typescript-eslint.io/docs/linting/type-linting) to learn more.
 
-If you wish to disable the strong type checks (which will turn off many of the recommended rules), you can update your `.eslintrc.js` configuration as such:
+If you wish to disable the strong type checks (which will turn off many of the recommended rules), you can update your ESLint configuration as such:
 
-```js
-// .eslintrc.js
-module.exports = {
-  extends: ['@side/typescript/without-type-checks'],
-  overrides: [
+```jsonc
+{
+  "extends": ["@side/typescript/without-type-checks"],
+  "overrides": [
     {
-      files: ['*.ts', '*.tsx'],
-      parser: '@typescript-eslint/parser',
-    },
-  ],
-};
+      "files": ["**/*.ts?(x)"],
+      "parser": "@typescript-eslint/parser"
+    }
+  ]
+}
+```
+
+## Troubleshooting
+
+### Multiple `tsconfig.json` Files
+
+You may encounter errors like this if your project has multiple `tsconfig.json` files:
+
+> Parsing error: `parserOptions.project` has been set for @typescript-eslint/parser.
+> The file does not match your project config: `some/file/path.ts`
+> The file must be included in at least one of the projects provided.
+
+This issue occurs when ESLint tries to parse a file that is excluded within the default TypeScript config file (located at `<rootDir>/tsconfig.json`).
+
+To resolve this issue, you will need to configure separate `parserOptions` in ESLint for each additional `tsconfig.json`.
+
+For example: if your `cypress` directory has its own `tsconfig.json`, you could add this override to your ESLint configuration:
+
+```json
+{
+  "overrides": [
+    {
+      "files": ["cypress/**/*"],
+      "parserOptions": {
+        "project": "cypress/tsconfig.json"
+      }
+    }
+  ]
+}
 ```
 
 ## Resources
 
-For more information on configuring ESLint, please [refer to their documentation](https://eslint.org/docs/user-guide/configuring)
+For more information on configuring ESLint, please [refer to their documentation](https://eslint.org/docs/user-guide/configuring).

--- a/packages/eslint-config-typescript/eslint-config-typescript.js
+++ b/packages/eslint-config-typescript/eslint-config-typescript.js
@@ -1,9 +1,9 @@
 module.exports = {
   plugins: ['@typescript-eslint'],
-  extends: ['./rules/import'],
+  extends: ['plugin:import/typescript', './rules/import', './rules/react'],
   overrides: [
     {
-      files: ['*.ts', '*.tsx'],
+      files: ['**/*.ts?(x)'],
       extends: [
         './rules/base',
         'plugin:@typescript-eslint/recommended',

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -8,17 +8,20 @@
   "license": "UNLICENSED",
   "repository": {
     "type": "git",
-    "url": "http://github.com/reside-eng/lint-config.git"
+    "url": "http://github.com/reside-eng/lint-config.git",
+    "directory": "packages/eslint-config-typescript"
   },
   "bugs": {
     "url": "http://github.com/reside-eng/lint-config/issues"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "5.18.0"
+    "@typescript-eslint/eslint-plugin": "5.19.0",
+    "@typescript-eslint/parser": "5.19.0",
+    "eslint-import-resolver-typescript": "2.7.1"
   },
   "peerDependencies": {
-    "@typescript-eslint/parser": ">=5.18.0",
     "eslint": ">=7.14.0",
+    "eslint-plugin-import": ">=2.1.0",
     "typescript": ">=4.0.0"
   }
 }

--- a/packages/eslint-config-typescript/rules/import.js
+++ b/packages/eslint-config-typescript/rules/import.js
@@ -1,9 +1,15 @@
 module.exports = {
   settings: {
+    'import/parsers': {
+      [require.resolve('@typescript-eslint/parser')]: ['.ts', '.tsx', '.d.ts'],
+    },
     'import/extensions': ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
     'import/resolver': {
       node: {
         extensions: ['.js', '.jsx', '.mjs', '.json', '.ts', '.tsx'],
+      },
+      typescript: {
+        alwaysTryTypes: true,
       },
     },
   },

--- a/packages/eslint-config-typescript/rules/react.js
+++ b/packages/eslint-config-typescript/rules/react.js
@@ -1,0 +1,15 @@
+module.exports = {
+  overrides: [
+    {
+      files: ['**/*.tsx'],
+      rules: {
+        'react/jsx-filename-extension': [
+          'error',
+          {
+            extensions: ['.jsx', '.tsx'],
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/eslint-config-typescript/without-type-checks.js
+++ b/packages/eslint-config-typescript/without-type-checks.js
@@ -3,7 +3,7 @@ module.exports = {
   extends: ['./rules/import'],
   overrides: [
     {
-      files: ['*.ts', '*.tsx'],
+      files: ['**/*.ts?(x)'],
       extends: ['./rules/base', 'plugin:@typescript-eslint/recommended'],
       parser: '@typescript-eslint/parser',
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1164,20 +1164,30 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@typescript-eslint/eslint-plugin@5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.18.0.tgz#950df411cec65f90d75d6320a03b2c98f6c3af7d"
-  integrity sha512-tzrmdGMJI/uii9/V6lurMo4/o+dMTKDH82LkNjhJ3adCW22YQydoRs5MwTiqxGF9CSYxPxQ7EYb4jLNlIs+E+A==
+"@typescript-eslint/eslint-plugin@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.19.0.tgz#9608a4b6d0427104bccf132f058cba629a6553c0"
+  integrity sha512-w59GpFqDYGnWFim9p6TGJz7a3qWeENJuAKCqjGSx+Hq/bwq3RZwXYqy98KIfN85yDqz9mq6QXiY5h0FjGQLyEg==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.18.0"
-    "@typescript-eslint/type-utils" "5.18.0"
-    "@typescript-eslint/utils" "5.18.0"
+    "@typescript-eslint/scope-manager" "5.19.0"
+    "@typescript-eslint/type-utils" "5.19.0"
+    "@typescript-eslint/utils" "5.19.0"
     debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
     regexpp "^3.2.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
+
+"@typescript-eslint/parser@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.19.0.tgz#05e587c1492868929b931afa0cb5579b0f728e75"
+  integrity sha512-yhktJjMCJX8BSBczh1F/uY8wGRYrBeyn84kH6oyqdIJwTGKmzX5Qiq49LRQ0Jh0LXnWijEziSo6BRqny8nqLVQ==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.19.0"
+    "@typescript-eslint/types" "5.19.0"
+    "@typescript-eslint/typescript-estree" "5.19.0"
+    debug "^4.3.2"
 
 "@typescript-eslint/scope-manager@5.17.0":
   version "5.17.0"
@@ -1187,20 +1197,20 @@
     "@typescript-eslint/types" "5.17.0"
     "@typescript-eslint/visitor-keys" "5.17.0"
 
-"@typescript-eslint/scope-manager@5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.18.0.tgz#a7d7b49b973ba8cebf2a3710eefd457ef2fb5505"
-  integrity sha512-C0CZML6NyRDj+ZbMqh9FnPscg2PrzSaVQg3IpTmpe0NURMVBXlghGZgMYqBw07YW73i0MCqSDqv2SbywnCS8jQ==
+"@typescript-eslint/scope-manager@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.19.0.tgz#97e59b0bcbcb54dbcdfba96fc103b9020bbe9cb4"
+  integrity sha512-Fz+VrjLmwq5fbQn5W7cIJZ066HxLMKvDEmf4eu1tZ8O956aoX45jAuBB76miAECMTODyUxH61AQM7q4/GOMQ5g==
   dependencies:
-    "@typescript-eslint/types" "5.18.0"
-    "@typescript-eslint/visitor-keys" "5.18.0"
+    "@typescript-eslint/types" "5.19.0"
+    "@typescript-eslint/visitor-keys" "5.19.0"
 
-"@typescript-eslint/type-utils@5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.18.0.tgz#62dbfc8478abf36ba94a90ddf10be3cc8e471c74"
-  integrity sha512-vcn9/6J5D6jtHxpEJrgK8FhaM8r6J1/ZiNu70ZUJN554Y3D9t3iovi6u7JF8l/e7FcBIxeuTEidZDR70UuCIfA==
+"@typescript-eslint/type-utils@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.19.0.tgz#80f2125b0dfe82494bbae1ea99f1c0186d420282"
+  integrity sha512-O6XQ4RI4rQcBGshTQAYBUIGsKqrKeuIOz9v8bckXZnSeXjn/1+BDZndHLe10UplQeJLXDNbaZYrAytKNQO2T4Q==
   dependencies:
-    "@typescript-eslint/utils" "5.18.0"
+    "@typescript-eslint/utils" "5.19.0"
     debug "^4.3.2"
     tsutils "^3.21.0"
 
@@ -1209,10 +1219,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.17.0.tgz#861ec9e669ffa2aa9b873dd4d28d9b1ce26d216f"
   integrity sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==
 
-"@typescript-eslint/types@5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.18.0.tgz#4f0425d85fdb863071680983853c59a62ce9566e"
-  integrity sha512-bhV1+XjM+9bHMTmXi46p1Led5NP6iqQcsOxgx7fvk6gGiV48c6IynY0apQb7693twJDsXiVzNXTflhplmaiJaw==
+"@typescript-eslint/types@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.19.0.tgz#12d3d600d754259da771806ee8b2c842d3be8d12"
+  integrity sha512-zR1ithF4Iyq1wLwkDcT+qFnhs8L5VUtjgac212ftiOP/ZZUOCuuF2DeGiZZGQXGoHA50OreZqLH5NjDcDqn34w==
 
 "@typescript-eslint/typescript-estree@5.17.0":
   version "5.17.0"
@@ -1227,28 +1237,28 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.18.0.tgz#6498e5ee69a32e82b6e18689e2f72e4060986474"
-  integrity sha512-wa+2VAhOPpZs1bVij9e5gyVu60ReMi/KuOx4LKjGx2Y3XTNUDJgQ+5f77D49pHtqef/klglf+mibuHs9TrPxdQ==
+"@typescript-eslint/typescript-estree@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.19.0.tgz#fc987b8f62883f9ea6a5b488bdbcd20d33c0025f"
+  integrity sha512-dRPuD4ocXdaE1BM/dNR21elSEUPKaWgowCA0bqJ6YbYkvtrPVEvZ+zqcX5a8ECYn3q5iBSSUcBBD42ubaOp0Hw==
   dependencies:
-    "@typescript-eslint/types" "5.18.0"
-    "@typescript-eslint/visitor-keys" "5.18.0"
+    "@typescript-eslint/types" "5.19.0"
+    "@typescript-eslint/visitor-keys" "5.19.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.18.0.tgz#27fc84cf95c1a96def0aae31684cb43a37e76855"
-  integrity sha512-+hFGWUMMri7OFY26TsOlGa+zgjEy1ssEipxpLjtl4wSll8zy85x0GrUSju/FHdKfVorZPYJLkF3I4XPtnCTewA==
+"@typescript-eslint/utils@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.19.0.tgz#fe87f1e3003d9973ec361ed10d36b4342f1ded1e"
+  integrity sha512-ZuEckdupXpXamKvFz/Ql8YnePh2ZWcwz7APICzJL985Rp5C2AYcHO62oJzIqNhAMtMK6XvrlBTZeNG8n7gS3lQ==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.18.0"
-    "@typescript-eslint/types" "5.18.0"
-    "@typescript-eslint/typescript-estree" "5.18.0"
+    "@typescript-eslint/scope-manager" "5.19.0"
+    "@typescript-eslint/types" "5.19.0"
+    "@typescript-eslint/typescript-estree" "5.19.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -1272,12 +1282,12 @@
     "@typescript-eslint/types" "5.17.0"
     eslint-visitor-keys "^3.0.0"
 
-"@typescript-eslint/visitor-keys@5.18.0":
-  version "5.18.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.18.0.tgz#c7c07709823804171d569017f3b031ced7253e60"
-  integrity sha512-Hf+t+dJsjAKpKSkg3EHvbtEpFFb/1CiOHnvI8bjHgOD4/wAw3gKrA0i94LrbekypiZVanJu3McWJg7rWDMzRTg==
+"@typescript-eslint/visitor-keys@5.19.0":
+  version "5.19.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.19.0.tgz#c84ebc7f6c744707a361ca5ec7f7f64cd85b8af6"
+  integrity sha512-Ym7zZoMDZcAKWsULi2s7UMLREdVQdScPQ/fKWMYefarCztWlHPFVJo8racf8R0Gc8FAEJ2eD4of8As1oFtnQlQ==
   dependencies:
-    "@typescript-eslint/types" "5.18.0"
+    "@typescript-eslint/types" "5.19.0"
     eslint-visitor-keys "^3.0.0"
 
 JSONStream@^1.0.4:


### PR DESCRIPTION
## Changes

- Added `@typescript-eslint/parser` as a dependency.
- Switched TypeScript file glob to match Next.js's pattern.
- Added documentation for troubleshooting multiple `tsconfig.json` files.
