### PR TITLE
feat(base): add support for firebase-admin v10 imports [PLAT-1324]

### DIFF
--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -110,6 +110,24 @@ module.exports = {
         ],
       },
     ],
+    /**
+     * Handling for firebase-admin >10 module imports [PLAT-1324]
+     * NOTE: This is added since eslint-plugin-import does not support exports in package.json
+     * which is what firebase-admin v10 uses. See: https://github.com/import-js/eslint-plugin-import/issues/1810
+     */
+    'import/no-unresolved': [
+      2,
+      {
+        ignore: [
+          'firebase-admin/app',
+          'firebase-admin/auth',
+          'firebase-admin/database',
+          'firebase-admin/firestore',
+          'firebase-admin/functions',
+          'firebase-admin/storage',
+        ],
+      },
+    ],
   },
   overrides: [
     ...getNoExtraneousDepsOverrides(),

--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -113,7 +113,8 @@ module.exports = {
     /**
      * Handling for firebase-admin >10 module imports [PLAT-1324]
      * NOTE: This is added since eslint-plugin-import does not support exports in package.json
-     * which is what firebase-admin v10 uses. See: https://github.com/import-js/eslint-plugin-import/issues/1810
+     * which is what firebase-admin v10 uses.
+     * @see https://github.com/import-js/eslint-plugin-import/issues/1810
      */
     'import/no-unresolved': [
       2,


### PR DESCRIPTION
firebase-admin has imports defined in package.json which eslint-plugin-import does not currently support [as described in this issue](https://github.com/import-js/eslint-plugin-import/issues/1810)