### PR TITLE
feat: add shared lint staged config

### DIFF
--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -1,0 +1,24 @@
+# `@side/lint-staged-config`
+
+This is a shared configuration for [lint-staged][lint-staged] that is used within JavaScript, Node.js, and TypeScript projects across `reside-eng`.
+
+## Setup
+
+### Install lint-staged with shared configuration
+
+Install lint-staged and this shared configuration package.
+
+```bash
+yarn add -D lint-staged @side/lint-staged-config
+```
+
+Then, create a `.lintstagedrc.js` to use the shared configuration.
+
+```js
+// .lintstagedrc.js
+module.exports = {
+  ...require('@side/lint-staged-config'),
+};
+```
+
+[lint-staged]: https://github.com/okonet/lint-staged#readme 'lint-staged'

--- a/packages/lint-staged-config/README.md
+++ b/packages/lint-staged-config/README.md
@@ -12,10 +12,10 @@ Install lint-staged and this shared configuration package.
 yarn add -D lint-staged @side/lint-staged-config
 ```
 
-Then, create a `.lintstagedrc.js` to use the shared configuration.
+Then, create a `lint-staged.config.js` file to use the shared configuration.
 
 ```js
-// .lintstagedrc.js
+// lint-staged.config.js
 module.exports = {
   ...require('@side/lint-staged-config'),
 };

--- a/packages/lint-staged-config/index.js
+++ b/packages/lint-staged-config/index.js
@@ -17,5 +17,7 @@ module.exports = {
       `prettier --write ${files.join(' ')}`,
     ];
   },
-  '*.{yaml,yml,json,md}': (files) => [`prettier --write ${files.join(' ')}`],
+  '*.{yaml,yml,json,md,html,css}': (files) => [
+    `prettier --write ${files.join(' ')}`,
+  ],
 };

--- a/packages/lint-staged-config/index.js
+++ b/packages/lint-staged-config/index.js
@@ -12,7 +12,10 @@ const removeIgnoredFiles = async (files) => {
 module.exports = {
   '*.{ts,tsx,js,jsx}': async (files) => {
     const filesToLint = await removeIgnoredFiles(files);
-    return [`eslint --max-warnings=0 --fix ${filesToLint}`, 'prettier --write'];
+    return [
+      `eslint --max-warnings=0 --fix ${filesToLint}`,
+      `prettier --write ${files.join(' ')}`,
+    ];
   },
   '*.{yaml,yml,json,md}': ['prettier --write'],
 };

--- a/packages/lint-staged-config/index.js
+++ b/packages/lint-staged-config/index.js
@@ -1,0 +1,18 @@
+const { ESLint } = require('eslint');
+
+const removeIgnoredFiles = async (files) => {
+  const eslint = new ESLint();
+  const isIgnored = await Promise.all(
+    files.map((file) => eslint.isPathIgnored(file)),
+  );
+  const filteredFiles = files.filter((_, i) => !isIgnored[i]);
+  return filteredFiles.join(' ');
+};
+
+module.exports = {
+  '*.{ts,tsx,js,jsx}': async (files) => {
+    const filesToLint = await removeIgnoredFiles(files);
+    return [`eslint --max-warnings=0 --fix ${filesToLint}`, 'prettier --write'];
+  },
+  '*.{yaml,yml,json,md}': ['prettier --write'],
+};

--- a/packages/lint-staged-config/index.js
+++ b/packages/lint-staged-config/index.js
@@ -17,5 +17,5 @@ module.exports = {
       `prettier --write ${files.join(' ')}`,
     ];
   },
-  '*.{yaml,yml,json,md}': ['prettier --write'],
+  '*.{yaml,yml,json,md}': (files) => [`prettier --write ${files.join(' ')}`],
 };

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@side/lint-staged-config",
+  "description": "Standard lint staged config for Side projects",
+  "version": "0.0.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/reside-eng/lint-config.git"
+  },
+  "bugs": {
+    "url": "http://github.com/reside-eng/lint-config/issues"
+  },
+  "main": "index.js",
+  "peerDependencies": {
+    "eslint": ">=7.14.0",
+    "lint-staged": ">=13.0.0"
+  }
+}

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -13,6 +13,7 @@
   "main": "index.js",
   "peerDependencies": {
     "eslint": ">=7.14.0",
-    "lint-staged": ">=13.0.0"
+    "lint-staged": ">=13.0.0",
+    "prettier": ">=2.7.0"
   }
 }


### PR DESCRIPTION
Add lint staged config so it can be shared across projects.  This is a configuration that I've seen added to several repos so we correctly ignore linting files that should be ignored by the .eslintignore file