### PR TITLE
fix: add lint-staged.config file to imports settings

### DIFF
--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -63,7 +63,7 @@ module.exports = {
           'test.{js,jsx}', // repos with a single test file
           'test-*.{js,jsx}', // repos with multiple top-level test files
           '**/*{.,_}{test,spec}.{js,jsx}', // tests where the extension or filename suffix denotes that it is a test
-          '**/jest.config.js', // jest config
+          '**/jest.config.{js,ts}', // jest config
           '**/jest.setup.js', // jest setup
           '**/vue.config.js', // vue-cli config
           '**/webpack.config.js', // webpack config
@@ -84,6 +84,7 @@ module.exports = {
           '**/babel.config.js',
           '**/*.stories.{js,jsx}',
           '**/.eslintrc.js',
+          '**/lint-staged.config.js', // lint-staged config
           //
           // Support for TypeScript extensions
           'test.{ts,tsx}', // repos with a single test file


### PR DESCRIPTION
Adds `lint-staged.config.js` to imports settings to prevent extraneous dependencies lint error