### PR TITLE
feat: allow loops over iterators

### DIFF
--- a/packages/eslint-config-base/rules/errors.js
+++ b/packages/eslint-config-base/rules/errors.js
@@ -29,6 +29,8 @@ module.exports = {
         caughtErrorsIgnorePattern: '^_',
       },
     ],
+    // Allow for-of loops over iterators
+    'no-restricted-syntax': 0,
   },
   overrides: [
     {


### PR DESCRIPTION
## Changes

Turned off the `no-restricted-syntax` rule.

By turning off this rule, we are allowed to use `for..of` to iterate over any iterable object, be it an Array, Map, Set, etc.

It appears that the rule existed for compatibility purposes for supporting pre-ES2015 environments that would have required babel runtime to support iterators.
