### PR TITLE
ci: include Next.js Jest package dist in git

### DIFF
--- a/packages/jest-config-next/.gitignore
+++ b/packages/jest-config-next/.gitignore
@@ -89,7 +89,7 @@ out
 
 # Nuxt.js build / generate output
 .nuxt
-dist
+# dist
 
 # Gatsby files
 .cache/

--- a/packages/jest-config-next/dist/index.d.ts
+++ b/packages/jest-config-next/dist/index.d.ts
@@ -1,0 +1,1 @@
+export * from './make.js';

--- a/packages/jest-config-next/dist/index.js
+++ b/packages/jest-config-next/dist/index.js
@@ -1,0 +1,1 @@
+export * from './make.js';

--- a/packages/jest-config-next/dist/internals/base.d.ts
+++ b/packages/jest-config-next/dist/internals/base.d.ts
@@ -1,0 +1,13 @@
+import type { Config } from '@jest/types';
+export declare const baseConfig: {
+    testEnvironment: string;
+    coverageReporters: ("json-summary" | "lcov")[];
+    fakeTimers: {
+        enableGlobally: true;
+    };
+    collectCoverageFrom: string[];
+    setupFilesAfterEnv: string[];
+    moduleDirectories: string[];
+    testPathIgnorePatterns: string[];
+};
+export type DefinedConfig = typeof baseConfig & Config.InitialOptions;

--- a/packages/jest-config-next/dist/internals/base.js
+++ b/packages/jest-config-next/dist/internals/base.js
@@ -1,0 +1,23 @@
+export const baseConfig = {
+  testEnvironment: 'jsdom',
+  coverageReporters: ['lcov', 'json-summary'],
+  fakeTimers: {
+    enableGlobally: true,
+  },
+  collectCoverageFrom: [
+    '<rootDir>/src/**/*.{js,jsx,ts,tsx}',
+    '!**/*.stories.*',
+    '!**/*.generated.*',
+    '!**/generated/**',
+    '!**/__snapshots__/**',
+    '!**/*.d.ts',
+    '!**/node_modules/**',
+  ],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleDirectories: ['node_modules', '<rootDir>'],
+  testPathIgnorePatterns: [
+    '<rootDir>/node_modules/',
+    '<rootDir>/.next/',
+    '<rootDir>/cypress/',
+  ],
+};

--- a/packages/jest-config-next/dist/internals/logs.d.ts
+++ b/packages/jest-config-next/dist/internals/logs.d.ts
@@ -1,0 +1,2 @@
+export declare function showWarning(message: string): void;
+export declare function showError(message: string): void;

--- a/packages/jest-config-next/dist/internals/logs.js
+++ b/packages/jest-config-next/dist/internals/logs.js
@@ -1,0 +1,23 @@
+import boxen from 'boxen';
+const baseOptions = {
+  title: '@side/jest-config-next',
+  titleAlignment: 'center',
+  padding: 1,
+  textAlignment: 'center',
+};
+export function showWarning(message) {
+  console.log(
+    boxen(message, {
+      ...baseOptions,
+      borderColor: 'yellowBright',
+    }),
+  );
+}
+export function showError(message) {
+  console.log(
+    boxen(message, {
+      ...baseOptions,
+      borderColor: 'redBright',
+    }),
+  );
+}

--- a/packages/jest-config-next/dist/internals/verification.d.ts
+++ b/packages/jest-config-next/dist/internals/verification.d.ts
@@ -1,0 +1,5 @@
+/**
+ * Warn if babel-jest is installed, since this package is
+ * using the Next.js compiler instead
+ */
+export declare function detectBabelJest(): void;

--- a/packages/jest-config-next/dist/internals/verification.js
+++ b/packages/jest-config-next/dist/internals/verification.js
@@ -1,0 +1,28 @@
+import path from 'node:path';
+import fs from 'node:fs';
+import chalk from 'chalk';
+import { showError } from './logs.js';
+/**
+ * Warn if babel-jest is installed, since this package is
+ * using the Next.js compiler instead
+ */
+export function detectBabelJest() {
+  // Detect package.json
+  const pkgPath = path.resolve(process.cwd(), 'packages.json');
+  if (!fs.existsSync(pkgPath)) return;
+  // Import package.json
+  const pkgFile = fs.readFileSync(pkgPath, { encoding: 'utf-8' });
+  if (!pkgFile) return;
+  // Look for babel-jest
+  const pkg = JSON.parse(pkgFile);
+  if (
+    pkg?.dependencies?.['babel-jest'] ||
+    pkg?.devDependencies?.['babel-jest']
+  ) {
+    showError(
+      `${chalk.bold(
+        'Please uninstall babel-jest.',
+      )}\n\nThe Next.js compiler is being used instead.`,
+    );
+  }
+}

--- a/packages/jest-config-next/dist/make.d.ts
+++ b/packages/jest-config-next/dist/make.d.ts
@@ -1,0 +1,21 @@
+import type { Config } from '@jest/types';
+import { type DefinedConfig } from './internals/base.js';
+export type MakeConfigOptions = {
+    /**
+     * Aliases that correspond to any `paths` defined in tsconfig.json
+     */
+    moduleAliases?: NonNullable<Config.InitialOptions['moduleNameMapper']>;
+    /**
+     * Overrides to make to the base config
+     */
+    overrides?: (config: DefinedConfig) => Config.InitialOptions | Promise<Config.InitialOptions>;
+    /**
+     * Quantity of workers to allow in a CI environment
+     */
+    maxCIWorkerCount?: NonNullable<Config.InitialOptions['maxWorkers']>;
+    /**
+     * Absolute path to Next.js project directory
+     */
+    dir?: string;
+};
+export declare function makeConfig({ moduleAliases, overrides, maxCIWorkerCount, dir, }?: MakeConfigOptions): Promise<() => Promise<any>>;

--- a/packages/jest-config-next/dist/make.js
+++ b/packages/jest-config-next/dist/make.js
@@ -1,0 +1,30 @@
+import createJestConfig from 'next/jest.js';
+import path from 'node:path';
+import { baseConfig } from './internals/base.js';
+import { detectBabelJest } from './internals/verification.js';
+export async function makeConfig({
+  moduleAliases = {},
+  overrides,
+  maxCIWorkerCount = 2,
+  dir = path.join(process.cwd(), './'),
+} = {}) {
+  // Verify environment preconditions
+  detectBabelJest();
+  // Copy base config
+  const config = { ...baseConfig };
+  // CI max workers
+  if (typeof maxCIWorkerCount === 'number' && process.env['CI'] === 'true') {
+    config.maxWorkers = maxCIWorkerCount;
+  }
+  // Module aliases
+  config.moduleNameMapper = moduleAliases;
+  let finalConfig;
+  if (typeof overrides === 'function') {
+    // Use function-based override
+    finalConfig = await overrides(config);
+  } else {
+    // Use unmodified config
+    finalConfig = config;
+  }
+  return createJestConfig({ dir })(finalConfig);
+}

--- a/packages/jest-config-next/package.json
+++ b/packages/jest-config-next/package.json
@@ -17,9 +17,7 @@
     "url": "http://github.com/reside-eng/lint-config/issues"
   },
   "scripts": {
-    "prepublish": "yarn build",
-    "prebuild": "del ./dist",
-    "build": "tsc --project ./tsconfig.json"
+    "build": "del ./dist && tsc --project ./tsconfig.json"
   },
   "devDependencies": {
     "@tsconfig/node-lts-strictest-esm": "18.12.1",


### PR DESCRIPTION
## Changes 

Due to lerna build issues, this PR includes the `dist` directory of the Next.js Jest package within version control.

## Notes for Reviewers

Building packages at runtime using our current yarn workspaces/lerna configuration is causing build failures with Typescript packages. It appears that there is unwanted hoisting going on that causes the wrong version of TypeScript to be used when building the `@side/jest-config-next` package. 

Including the `dist` for that package in version control seems to be an effective remedy for this issue until we can debug the larger issue with lerna/yarn.