### PR TITLE
chore(release): bump versions

### DIFF
--- a/packages/commitlint-config/CHANGELOG.md
+++ b/packages/commitlint-config/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/commitlint-config@0.2.0...@side/commitlint-config@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/commitlint-config
+
 # [0.2.0](https://github.com/reside-eng/lint-config/compare/@side/commitlint-config@0.1.12...@side/commitlint-config@0.2.0) (2023-03-29)
 
 ### Features

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/commitlint-config",
-  "version": "0.2.0",
+  "version": "1.0.0-alpha.0",
   "main": "commitlint-config.js",
   "files": [
     "commitlint-config.js",

--- a/packages/commitlint-config/package.json
+++ b/packages/commitlint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/commitlint-config",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "main": "commitlint-config.js",
   "files": [
     "commitlint-config.js",

--- a/packages/eslint-config-base/CHANGELOG.md
+++ b/packages/eslint-config-base/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-base@0.17.0...@side/eslint-config-base@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/eslint-config-base
+
 # [0.17.0](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-base@0.16.1...@side/eslint-config-base@0.17.0) (2023-03-29)
 
 ### Features

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-base",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "main": "eslint-config-base.js",
   "files": [
     "eslint-config-base.js",

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-base",
-  "version": "0.17.0",
+  "version": "1.0.0-alpha.0",
   "main": "eslint-config-base.js",
   "files": [
     "eslint-config-base.js",

--- a/packages/eslint-config-cypress/CHANGELOG.md
+++ b/packages/eslint-config-cypress/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-cypress@0.6.0...@side/eslint-config-cypress@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/eslint-config-cypress
+
 # [0.6.0](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-cypress@0.5.0...@side/eslint-config-cypress@0.6.0) (2023-03-29)
 
 ### Features

--- a/packages/eslint-config-cypress/package.json
+++ b/packages/eslint-config-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-cypress",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "main": "index.js",
   "license": "UNLICENSED",
   "repository": {

--- a/packages/eslint-config-cypress/package.json
+++ b/packages/eslint-config-cypress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-cypress",
-  "version": "0.6.0",
+  "version": "1.0.0-alpha.0",
   "main": "index.js",
   "license": "UNLICENSED",
   "repository": {

--- a/packages/eslint-config-jest/CHANGELOG.md
+++ b/packages/eslint-config-jest/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-jest@0.7.0...@side/eslint-config-jest@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/eslint-config-jest
+
 # [0.7.0](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-jest@0.6.1...@side/eslint-config-jest@0.7.0) (2023-03-29)
 
 ### Features

--- a/packages/eslint-config-jest/package.json
+++ b/packages/eslint-config-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-jest",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "main": "index.js",
   "license": "UNLICENSED",
   "repository": {

--- a/packages/eslint-config-jest/package.json
+++ b/packages/eslint-config-jest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-jest",
-  "version": "0.7.0",
+  "version": "1.0.0-alpha.0",
   "main": "index.js",
   "license": "UNLICENSED",
   "repository": {

--- a/packages/eslint-config-next/CHANGELOG.md
+++ b/packages/eslint-config-next/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [2.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-next@1.1.0...@side/eslint-config-next@2.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/eslint-config-next
+
 # [1.1.0](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-next@1.0.21...@side/eslint-config-next@1.1.0) (2023-03-29)
 
 ### Features

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-next",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-alpha.1",
   "main": "index.js",
   "license": "UNLICENSED",
   "repository": {
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@next/eslint-plugin-next": "13.2.4",
-    "@side/eslint-config-cypress": "^1.0.0-alpha.0",
-    "@side/eslint-config-jest": "^1.0.0-alpha.0",
-    "@side/eslint-config-react": "^1.0.0-alpha.0",
+    "@side/eslint-config-cypress": "1.0.0-alpha.1",
+    "@side/eslint-config-jest": "1.0.0-alpha.1",
+    "@side/eslint-config-react": "1.0.0-alpha.1",
     "@side/eslint-config-typescript": "1.1.0"
   },
   "peerDependencies": {

--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-next",
-  "version": "1.1.0",
+  "version": "2.0.0-alpha.0",
   "main": "index.js",
   "license": "UNLICENSED",
   "repository": {
@@ -16,9 +16,9 @@
   },
   "dependencies": {
     "@next/eslint-plugin-next": "13.2.4",
-    "@side/eslint-config-cypress": "0.6.0",
-    "@side/eslint-config-jest": "0.7.0",
-    "@side/eslint-config-react": "0.17.0",
+    "@side/eslint-config-cypress": "^1.0.0-alpha.0",
+    "@side/eslint-config-jest": "^1.0.0-alpha.0",
+    "@side/eslint-config-react": "^1.0.0-alpha.0",
     "@side/eslint-config-typescript": "1.1.0"
   },
   "peerDependencies": {

--- a/packages/eslint-config-react/CHANGELOG.md
+++ b/packages/eslint-config-react/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-react@0.17.0...@side/eslint-config-react@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/eslint-config-react
+
 # [0.17.0](https://github.com/reside-eng/lint-config/compare/@side/eslint-config-react@0.16.1...@side/eslint-config-react@0.17.0) (2023-03-29)
 
 ### Features

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-react",
-  "version": "0.17.0",
+  "version": "1.0.0-alpha.0",
   "main": "eslint-config-react.js",
   "files": [
     "eslint-config-react.js",
@@ -20,7 +20,7 @@
     "test": "node eslint-config-react.js && node hooks.js"
   },
   "dependencies": {
-    "@side/eslint-config-base": "0.17.0",
+    "@side/eslint-config-base": "^1.0.0-alpha.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.5.1",

--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@side/eslint-config-react",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "main": "eslint-config-react.js",
   "files": [
     "eslint-config-react.js",
@@ -20,7 +20,7 @@
     "test": "node eslint-config-react.js && node hooks.js"
   },
   "dependencies": {
-    "@side/eslint-config-base": "^1.0.0-alpha.0",
+    "@side/eslint-config-base": "1.0.0-alpha.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-plugin-import": "^2.25.3",
     "eslint-plugin-jsx-a11y": "^6.5.1",

--- a/packages/jest-config-next/CHANGELOG.md
+++ b/packages/jest-config-next/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/jest-config-next@0.2.1...@side/jest-config-next@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/jest-config-next
+
 ## [0.2.1](https://github.com/reside-eng/lint-config/compare/@side/jest-config-next@0.2.0...@side/jest-config-next@0.2.1) (2023-03-29)
 
 **Note:** Version bump only for package @side/jest-config-next

--- a/packages/jest-config-next/package.json
+++ b/packages/jest-config-next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@side/jest-config-next",
   "description": "Jest config for Next.js apps",
-  "version": "0.2.1",
+  "version": "1.0.0-alpha.0",
   "type": "module",
   "types": "./dist/index.d.ts",
   "files": [
@@ -27,7 +27,7 @@
     "lint": "eslint src/**/*"
   },
   "devDependencies": {
-    "@side/eslint-config-base": "0.17.0",
+    "@side/eslint-config-base": "^1.0.0-alpha.0",
     "@side/eslint-config-typescript": "1.1.0",
     "@tsconfig/node-lts-strictest-esm": "18.12.1",
     "@types/node": "18.15.11",

--- a/packages/jest-config-next/package.json
+++ b/packages/jest-config-next/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@side/jest-config-next",
   "description": "Jest config for Next.js apps",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "type": "module",
   "types": "./dist/index.d.ts",
   "files": [
@@ -27,7 +27,7 @@
     "lint": "eslint src/**/*"
   },
   "devDependencies": {
-    "@side/eslint-config-base": "^1.0.0-alpha.0",
+    "@side/eslint-config-base": "1.0.0-alpha.1",
     "@side/eslint-config-typescript": "1.1.0",
     "@tsconfig/node-lts-strictest-esm": "18.12.1",
     "@types/node": "18.15.11",

--- a/packages/lint-staged-config/CHANGELOG.md
+++ b/packages/lint-staged-config/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/lint-staged-config@0.2.0...@side/lint-staged-config@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/lint-staged-config
+
 # [0.2.0](https://github.com/reside-eng/lint-config/compare/@side/lint-staged-config@0.1.0...@side/lint-staged-config@0.2.0) (2023-03-29)
 
 ### Features

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@side/lint-staged-config",
   "description": "Standard lint staged config for Side projects",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/lint-staged-config/package.json
+++ b/packages/lint-staged-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@side/lint-staged-config",
   "description": "Standard lint staged config for Side projects",
-  "version": "0.2.0",
+  "version": "1.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/prettier-config/CHANGELOG.md
+++ b/packages/prettier-config/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.0.0-alpha.1](https://github.com/reside-eng/lint-config/compare/@side/prettier-config@0.1.0...@side/prettier-config@1.0.0-alpha.1) (2023-03-29)
+
+**Note:** Version bump only for package @side/prettier-config
+
 # [0.1.0](https://github.com/reside-eng/lint-config/compare/@side/prettier-config@0.0.0...@side/prettier-config@0.1.0) (2023-03-29)
 
 ### Features

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@side/prettier-config",
   "description": "Standard Prettier configuration for Side projects",
-  "version": "0.1.0",
+  "version": "1.0.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@side/prettier-config",
   "description": "Standard Prettier configuration for Side projects",
-  "version": "1.0.0-alpha.0",
+  "version": "1.0.0-alpha.1",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Changes

Bump packages to stable versions.

## Notes for Reviewers

Packages that depended on `v0.x` have also received a major version bump, since that's how Lerna appears to handle it.