### PR TITLE
fix: ignore gha-creds-*.json in prettier config

### DIFF
--- a/packages/prettier-config/index.json
+++ b/packages/prettier-config/index.json
@@ -1,5 +1,13 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "$schema": "http://json.schemastore.org/prettierrc"
+  "$schema": "http://json.schemastore.org/prettierrc",
+  "overrides": [
+    {
+      "files": ["./gha-creds-*.json"],
+      "options": {
+        "requirePragma": true
+      }
+    }
+  ]
 }


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
Fixes prettier error seen from GH credentials through shared config so that each repo doesn't need to ignore this file

Issue seen here: https://github.com/reside-eng/test-nextjs-ci/actions/runs/4821766907/jobs/8588109192#step:23:43
![image](https://user-images.githubusercontent.com/2992224/234923146-4280042b-ae61-458a-af37-2d62a3e995c6.png)

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
