### PR TITLE
feat(eslint-typescript): turn off types/interfaces rule

### DIFF
--- a/packages/eslint-config-typescript/rules/typescript-eslint.js
+++ b/packages/eslint-config-typescript/rules/typescript-eslint.js
@@ -13,6 +13,7 @@ module.exports = {
             caughtErrorsIgnorePattern: '^_',
           },
         ],
+        '@typescript-eslint/consistent-type-definitions': 'off',
       },
     },
   ],


### PR DESCRIPTION
## Changes

Turned off a rule that tried to enforce a convention of using only `type` or `interface`, but not both.

## Notes for Reviewers

We use both keywords across our projects for different reasons. The recent major update to TypeScript ESLint added a rule that requires you to prefer one or the other. This PR turns that rule off, since we don't have an official recommendation to prefer one variant.