### PR TITLE
fix(lint-staged-config): use ignore-path instead of custom files list

### DIFF
--- a/packages/lint-staged-config/index.js
+++ b/packages/lint-staged-config/index.js
@@ -14,10 +14,10 @@ module.exports = {
     const filesToLint = await removeIgnoredFiles(files);
     return [
       `eslint --max-warnings=0 --fix ${filesToLint}`,
-      `prettier --write ${filesToLint}`,
+      `prettier --write --ignore-path=.eslintignore ${files.join(' ')}`,
     ];
   },
   '*.{yaml,yml,json,md,html,css}': (files) => [
-    `prettier --write ${filesToLint}`,
+    `prettier --write --ignore-path=.eslintignore ${files.join(' ')}`,
   ],
 };


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
* Switch to ignore-path argument within call to prettier instead of custom files array - this makes the debug logs from lint-staged debug more clear and avoids some cases of erroneous error messages from lint-staged

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots
![image](https://github.com/reside-eng/lint-config/assets/2992224/952c1c70-637a-4dc0-8b60-7295b8c13371)

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
