### PR TITLE
fix: support default export in config files for ESM repos

### DIFF
--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -153,5 +153,17 @@ module.exports = {
         'import/no-default-export': 'off',
       },
     },
+    // Support vitest nested imports within vitest.config
+    {
+      files: ['./vitest.config.ts'],
+      rules: {
+        'import/no-unresolved': [
+          'error',
+          {
+            ignore: ['^vitest/.+'],
+          },
+        ],
+      },
+    },
   ],
 };

--- a/packages/eslint-config-base/rules/imports.js
+++ b/packages/eslint-config-base/rules/imports.js
@@ -142,7 +142,13 @@ module.exports = {
     ...getNoExtraneousDepsOverrides(),
     // This override enables default exports for files that require them.
     {
-      files: ['jest.config.{js,ts,mjs,cjs}', 'vitest.config.{js,ts,mjs,cjs}'],
+      files: [
+        'jest.config.{js,ts,mjs,cjs}',
+        'vitest.config.{js,ts,mjs,cjs}',
+        'commitlint.config.{js,ts,mjs,cjs}',
+        'lint-staged.config.{js,ts,mjs,cjs}',
+        'release.config.{js,ts,mjs,cjs}',
+      ],
       rules: {
         'import/no-default-export': 'off',
       },

--- a/packages/eslint-config-typescript/rules/import.js
+++ b/packages/eslint-config-typescript/rules/import.js
@@ -23,7 +23,7 @@ module.exports = {
         mjs: 'never',
         ts: 'never',
         tsx: 'never',
-        cjs: 'never'
+        cjs: 'never',
       },
     ],
   },

--- a/packages/eslint-config-typescript/rules/import.js
+++ b/packages/eslint-config-typescript/rules/import.js
@@ -3,10 +3,10 @@ module.exports = {
     'import/parsers': {
       [require.resolve('@typescript-eslint/parser')]: ['.ts', '.tsx', '.d.ts'],
     },
-    'import/extensions': ['.js', '.jsx', '.mjs', '.ts', '.tsx'],
+    'import/extensions': ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.cjs'],
     'import/resolver': {
       node: {
-        extensions: ['.js', '.jsx', '.mjs', '.json', '.ts', '.tsx'],
+        extensions: ['.js', '.jsx', '.mjs', '.json', '.ts', '.tsx', '.cjs'],
       },
       typescript: {
         alwaysTryTypes: true,
@@ -23,6 +23,7 @@ module.exports = {
         mjs: 'never',
         ts: 'never',
         tsx: 'never',
+        cjs: 'never'
       },
     ],
   },

--- a/packages/eslint-config-typescript/rules/typescript-eslint.js
+++ b/packages/eslint-config-typescript/rules/typescript-eslint.js
@@ -31,6 +31,9 @@ module.exports = {
         ],
         // NOTE: prefer-top-level causes duplicate imports for types
         'import/no-duplicates': ['error', { 'prefer-inline': true }],
+        // Disable jsdoc type arguments since types are defined in typescript
+        'jsdoc/require-returns-type': 0,
+        'jsdoc/require-param-type': 0,
       },
     },
   ],


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
* Support default exports within config files (now used in repos which are native ESM):
  * `commitlint.config.js`
  * `lint-staged.config.js`
  * `release.config.js`
* Add import extension support for `.cjs`
* Add nested import support for `vitest.config.js` (importing `vitest/config` triggers import/no-unresolved due to package imports)
<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers

<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
![image](https://github.com/reside-eng/lint-config/assets/2992224/624fa049-e661-45f2-834a-ede104ebf1ec)
