### PR TITLE
feat: add GitHub Actions reporters [PAY-7640]

### DIFF
--- a/packages/jest-config-next/src/internals/base.ts
+++ b/packages/jest-config-next/src/internals/base.ts
@@ -1,8 +1,15 @@
 import type { Config } from '@jest/types';
 
+const reporters: Config.InitialOptions['reporters'] = [];
+if (process.env['CI']) {
+  reporters.push(['github-actions', { silent: false }]);
+}
+reporters.push('default');
+
 export const baseConfig = {
   testEnvironment: 'jsdom',
   coverageReporters: ['lcov', 'json-summary'],
+  reporters,
   fakeTimers: {
     enableGlobally: true,
   },


### PR DESCRIPTION
:tickets: [PAY-7640](https://residenetwork.atlassian.net/browse/PAY-7640)

## Changes

Added the GitHub Actions reporter to our Jest reporters configuration.

## Notes for Reviewers

Review an example of this configuration here:

- https://github.com/reside-eng/payment-ui/pull/2566
  - [Workflow Annotations](https://github.com/reside-eng/payment-ui/actions/runs/10476107025) 
  - [Changed Files](https://github.com/reside-eng/payment-ui/pull/2566/files)

## Recordings/Screenshots

### Workflow Annotations

![CleanShot 2024-08-20 at 10 25 50@2x](https://github.com/user-attachments/assets/34f23aca-9897-47ec-9c4b-ad1efa44254d)


### Changed Files Annotations

![CleanShot 2024-08-20 at 10 25 42@2x](https://github.com/user-attachments/assets/f1a9e83d-be5d-4b15-8d8f-2d52fff33971)



[PAY-7640]: https://residenetwork.atlassian.net/browse/PAY-7640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ