### PR TITLE
feat(react): add react/no-default-props

### DIFF
--- a/packages/eslint-config-react/rules/react.js
+++ b/packages/eslint-config-react/rules/react.js
@@ -18,5 +18,7 @@ module.exports = {
     // discussion for context: https://top-agent.slack.com/archives/C0XU3K155/p1638225804365600?thread_ts=1638204245.354900&cid=C0XU3K155
     'react/function-component-definition': 'off',
     'react/require-default-props': 'off',
+    // React 19 does not support defaultProps
+    'react/no-default-props': 'error',
   },
 };


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs

<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
Add  react/no-default-props rule to react lint config to prevent usage of defaultProps (instead ES6 default values should be used on the props object)

[React 19 dropped support for defaultProps](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-react-apis) and this [caused a styling issue within a Pantry component](https://github.com/reside-eng/pantry/pull/2485)
<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers
If a UI has the newest version of `@types/react`, they will also get a typescript warning for this: 
![image](https://github.com/user-attachments/assets/789949c2-7620-4eab-bc6f-1f8b04123710)

This lint rule will actually error though, adding to enforcing
<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
